### PR TITLE
Headers constructor cannot be typer properly with TS

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import * as https from 'http';
 import { Options as RetryOptions } from 'async-retry';
-import { Request, RequestInit, Response, Headers } from 'node-fetch';
+import { Request, RequestInit, Response } from 'node-fetch';
 import FetchRetryError from './fetch-retry-error';
 
 export type FetchOptions = RequestInit & {
@@ -15,8 +15,7 @@ export type Fetch = {
 	(
 		url: string | Request,
 		options?: FetchOptions
-	): Promise<Response>;
-	Headers: Headers
+	): Promise<Response>
 }
 
 export type AgentOptions = http.AgentOptions | https.AgentOptions;


### PR DESCRIPTION
`Headers` is needed by us but it's impossible to type it properly
in the the current way this library works.