### PR TITLE
Allow any type as a body to fix serializing arbitrary objects

### DIFF
--- a/__test__/basic.test.ts
+++ b/__test__/basic.test.ts
@@ -56,6 +56,26 @@ test('switches agents on redirect', async () => {
 	expect(res.url).toBe('https://zeit.co/');
 });
 
+test('serializing arbitrary objects as JSON', async () => {
+	const server = createServer(async (req, res) => {
+		const body = await toBuffer(req);
+
+		expect(Buffer.isBuffer(body)).toBeTruthy();
+		expect(body.toString()).toBe('{"key":"value"}');
+
+		res.end();
+	});
+	servers.push(server);
+
+	await listen(server);
+
+	const { port } = getAddr(server);
+	const res = await fetch(`http://127.0.0.1:${port}`, {
+		method: 'POST',
+		body: { key: 'value' }
+	});
+});
+
 test('supports buffer request body', async () => {
 	const server = createServer(async (req, res) => {
 		const body = await toBuffer(req);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,11 +4,12 @@ import { Options as RetryOptions } from 'async-retry-ng';
 import { Request, RequestInit, Response } from 'node-fetch';
 import FetchRetryError from './fetch-retry-error';
 
-export type FetchOptions = RequestInit & {
+export interface FetchOptions extends RequestInit {
 	agent?: https.Agent | http.Agent;
 	retry?: RetryOptions;
 	onRedirect?: (res: Response, redirectOpts: FetchOptions) => void;
 	onRetry?: (error: FetchRetryError, opts: FetchOptions) => void;
+	body?: any; // allows automatic JSON serialization of objects
 }
 
 export type Fetch = {


### PR DESCRIPTION
This is an issue only with TS, where the only solution is to use
`JSON.stringfy()` and setting the `Content-Type` header before
passing an object as a body.

Fixes #12