### PR TITLE
Various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 yarn-error.log
 /dist
+/coverage

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2017, 2018 ZEIT, Inc.
-Copyright (c) 2019 Olli Vanhoja <olli.vanhoja@gmail.com>
+Copyright (c) 2019, 2020 Olli Vanhoja <olli.vanhoja@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/__test__/agent.test.ts
+++ b/__test__/agent.test.ts
@@ -1,4 +1,22 @@
+import * as http from 'http';
+import * as https from 'http';
 import AgentWrapper from '../src/agent-wrapper';
+
+test('http URL retruns a http Agent', () => {
+	const agentWrapper = new AgentWrapper({});
+
+	const agent = agentWrapper.getAgent('http://no.ne');
+
+	expect(agent).toBeInstanceOf(http.Agent);
+});
+
+test('https URL retruns a https Agent', () => {
+	const agentWrapper = new AgentWrapper({});
+
+	const agent = agentWrapper.getAgent('http://no.ne');
+
+	expect(agent).toBeInstanceOf(https.Agent);
+});
 
 test('Invalid protocol causes an error', () => {
 	const agentWrapper = new AgentWrapper({});

--- a/__test__/agent.test.ts
+++ b/__test__/agent.test.ts
@@ -1,0 +1,7 @@
+import AgentWrapper from '../src/agent-wrapper';
+
+test('Invalid protocol causes an error', () => {
+	const agentWrapper = new AgentWrapper({});
+
+	expect(() => agentWrapper.getAgent('htps://no.ne')).toThrow();
+});

--- a/__test__/basic.test.ts
+++ b/__test__/basic.test.ts
@@ -130,3 +130,13 @@ test('supports buffer request body', async () => {
 
 	expect(body).toEqual({ body: 'foo' })
 });
+
+test('does not modify original opts', async () => {
+	const opts = {
+		method: 'GET'
+	};
+
+	await fetch('http://google.com', opts);
+
+	expect(opts).toStrictEqual({ method: 'GET' });
+});

--- a/__test__/parse-host.test.ts
+++ b/__test__/parse-host.test.ts
@@ -1,0 +1,38 @@
+import { isIP } from 'net';
+import { Headers } from 'node-fetch';
+import parseHost from '../src/parse-host';
+
+test('Parses a domain to an IP address', async () => {
+	const [url, host] = await parseHost('http://google.com', new Headers());
+
+	const ip = url.substring(7, url.length - 1);
+	expect(isIP(ip)).toBeTruthy();
+
+	expect(host).toBe('google.com');
+});
+
+test('Leaves URL with IP address as is', async () => {
+	const url = 'http://127.0.0.1/this/is/path/file.txt?xyz=123&yes=no';
+	const [newUrl, host] = await parseHost(url, new Headers());
+
+	expect(newUrl).toBe(url);
+	expect(host).toBe('127.0.0.1');
+});
+
+test('Ports work', async () => {
+	const url = 'http://127.0.0.1:8080/this/is/path/file.txt?xyz=123&yes=no';
+	const [newUrl, host] = await parseHost(url, new Headers());
+
+	expect(newUrl).toBe(url);
+	expect(host).toBe('127.0.0.1:8080');
+});
+
+test('Host header is respected', async () => {
+	const url = 'https://amazon.com';
+	const [newUrl, host] = await parseHost(url, new Headers({ Host: 'ebay.com' }));
+
+	const ip = newUrl.substring(8, newUrl.length - 1);
+	expect(isIP(ip)).toBeTruthy();
+
+	expect(host).toBe('ebay.com');
+});

--- a/__test__/redirect.test.ts
+++ b/__test__/redirect.test.ts
@@ -1,0 +1,81 @@
+import AgentWrapper from '../src/agent-wrapper';
+import { Response } from 'node-fetch';
+import { isRedirect, makeRedirectOpts } from '../src/redirect';
+
+describe('isRedirect()', () => {
+	test('404 is not a redirect', () => {
+		const is = isRedirect(404);
+
+		expect(is).toBeFalsy();
+	});
+
+	test('300 is a redirect', () => {
+		const is = isRedirect(300);
+
+		expect(is).toBeTruthy();
+	});
+
+	test('301 is a redirect', () => {
+		const is = isRedirect(301);
+
+		expect(is).toBeTruthy();
+	});
+});
+
+describe('makeRedirectOpts()', () => {
+	let agentWrapper = new AgentWrapper({});
+
+	test('303 turns redirect request into a GET', () => {
+		const res = new Response(undefined, {
+			headers: {
+				Location: 'https://no.ne'
+			},
+			status: 303
+		});
+		const opts = {
+			method: 'HEAD'
+		};
+
+		const [location, redirectOpts] = makeRedirectOpts(res, opts, agentWrapper);
+
+		expect(location).toBe('https://no.ne');
+		expect(redirectOpts.method).toBe('GET');
+	});
+
+	test('301 turns POST into a GET on redirect', () => {
+		const body = 'test';
+		const res = new Response(undefined, {
+			headers: {
+				Location: 'https://no.ne',
+				'Content-Length': `${Buffer.from(body).length}`
+			},
+			status: 301
+		});
+		const opts = {
+			method: 'POST',
+			body
+		};
+
+		const [location, redirectOpts] = makeRedirectOpts(res, opts, agentWrapper);
+
+		expect(location).toBe('https://no.ne');
+		expect(redirectOpts.method).toBe('GET');
+		expect(redirectOpts.body).not.toBeDefined();
+
+		const headers = redirectOpts.headers;
+		expect(headers).toBeDefined();
+		// @ts-ignore
+		expect(headers.get('content-length')).toBeNull();
+	});
+
+	test('Throws if there is no Location on 300', () => {
+		const res = new Response(undefined, {
+			status: 300
+		});
+		const opts = {
+			method: 'GET'
+		};
+
+		expect(() => makeRedirectOpts(res, opts, agentWrapper)).toThrow();
+	});
+});

--- a/__test__/retry.test.ts
+++ b/__test__/retry.test.ts
@@ -89,7 +89,7 @@ test('accepts a custom onRetry option', async () => {
 			const { port } = getAddr(server);
 			const res = await fetch(`http://127.0.0.1:${port}`, opts);
 
-			expect(opts.onRetry.mock.calls.length).toBe(3);
+			expect(opts.onRetry).toHaveBeenCalledTimes(3)
 			expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(Error);
 			expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
 			expect(res.status).toBe(500);
@@ -122,8 +122,7 @@ test('handles Retry-After', async () => {
 			const res = await fetch(`http://127.0.0.1:${port}`, opts);
 			const endTime = time();
 
-
-			expect(opts.onRetry.mock.calls.length).toBe(1);
+			expect(opts.onRetry).toHaveBeenCalledTimes(1)
 			expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(Error);
 			expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
 			expect(res.status).toBe(429);

--- a/__test__/retry.test.ts
+++ b/__test__/retry.test.ts
@@ -91,7 +91,7 @@ test('accepts a custom onRetry option', async () => {
 
 			expect(opts.onRetry).toHaveBeenCalledTimes(3)
 			expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(Error);
-			expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
+			expect(opts.onRetry.mock.calls[0][1]).toBeTruthy();
 			expect(res.status).toBe(500);
 
 			return resolve();
@@ -124,7 +124,7 @@ test('handles Retry-After', async () => {
 
 			expect(opts.onRetry).toHaveBeenCalledTimes(1)
 			expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(Error);
-			expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
+			expect(opts.onRetry.mock.calls[0][1]).toBeTruthy();
 			expect(res.status).toBe(429);
 			expect(endTime - startTime).toBeCloseTo(1000, -3);
 

--- a/__test__/retry.test.ts
+++ b/__test__/retry.test.ts
@@ -84,7 +84,7 @@ test('accepts a custom onRetry option', async () => {
 			const { port } = getAddr(server);
 			const res = await fetch(`http://127.0.0.1:${port}`, opts);
 
-			expect(opts.onRetry.mock.calls.length).toBe(2);
+			expect(opts.onRetry.mock.calls.length).toBe(3);
 			expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(Error);
 			expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
 			expect(res.status).toBe(500);

--- a/__test__/retry.test.ts
+++ b/__test__/retry.test.ts
@@ -5,6 +5,11 @@ import { getAddr } from './util';
 const fetch = createFetch();
 let servers: Server[] = [];
 
+function time() {
+	const [seconds, nanos] = process.hrtime();
+	return seconds * 1000 + nanos / 1000000;
+}
+
 afterEach(() => {
 	while (servers.length) {
 		const server = servers.pop();
@@ -94,3 +99,38 @@ test('accepts a custom onRetry option', async () => {
 		server.on('error', reject);
 	});
 })
+
+test('handles Retry-After', async () => {
+	const server = createServer((_req: IncomingMessage, res: ServerResponse) => {
+		res.writeHead(429, { 'Retry-After': 1 });
+		res.end();
+	});
+	servers.push(server);
+
+	return new Promise((resolve, reject) => {
+		const opts = {
+			onRetry: jest.fn(),
+			retry: {
+				retries: 1
+			}
+		}
+
+		server.listen(async () => {
+			const { port } = getAddr(server);
+
+			const startTime = time();
+			const res = await fetch(`http://127.0.0.1:${port}`, opts);
+			const endTime = time();
+
+
+			expect(opts.onRetry.mock.calls.length).toBe(1);
+			expect(opts.onRetry.mock.calls[0][0]).toBeInstanceOf(Error);
+			expect(opts.onRetry.mock.calls[0][1]).toEqual(opts);
+			expect(res.status).toBe(429);
+			expect(endTime - startTime).toBeCloseTo(1000, -3);
+
+			return resolve();
+		});
+		server.on('error', reject);
+	});
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/debug": "4.1.5",
-    "@types/jest": "25.1.2",
+    "@types/jest": "25.1.3",
     "@types/lru-cache": "5.1.0",
     "@zeit/git-hooks": "0.1.4",
     "@zeit/ncc": "0.21.1",
@@ -31,8 +31,8 @@
     "lru-cache": "5.1.1",
     "node-fetch": "2.6.0",
     "raw-body": "2.4.1",
-    "ts-jest": "25.2.0",
-    "typescript": "3.7.5",
+    "ts-jest": "25.2.1",
+    "typescript": "3.8.3",
     "typescript-formatter": "7.2.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "prettier": "find . -path './**/*.ts' -not -path '*/node_modules/*'  -not -path '*/dist/*' -exec sh -c 'for n; do tsfmt -r \"$n\" || exit 1; done' sh {} +",
     "git-pre-commit": "find . -path './**/*.ts' -not -path '*/node_modules/*' -not -path '*/dist/*' -exec sh -c 'for n; do tsfmt --verify \"$n\" || exit 1; done' sh {} +",
-    "test": "jest",
+    "test": "jest --coverage",
     "build": "rm -rf ./dist && ncc build src/index.ts -m -s -o dist",
     "prepublish": "npm run build"
   },

--- a/src/agent-wrapper.ts
+++ b/src/agent-wrapper.ts
@@ -4,20 +4,20 @@ import HttpAgent from 'agentkeepalive';
 import { AgentOptions } from './types';
 
 export default class Agent {
-	defaultHttpAgent: http.Agent;
-	defaultHttpsAgent: https.Agent;
+	#defaultHttpAgent: http.Agent;
+	#defaultHttpsAgent: https.Agent;
 
 	constructor(agentOpts: AgentOptions) {
-		this.defaultHttpAgent = new HttpAgent(agentOpts);
+		this.#defaultHttpAgent = new HttpAgent(agentOpts);
 		// @ts-ignore
-		this.defaultHttpsAgent = new HttpAgent.HttpsAgent(agentOpts);
+		this.#defaultHttpsAgent = new HttpAgent.HttpsAgent(agentOpts);
 	}
 
 	getAgent(url: string) {
 		if (url.startsWith('https:')) {
-			return this.defaultHttpsAgent;
+			return this.#defaultHttpsAgent;
 		} else if (url.startsWith('http:')) {
-			return this.defaultHttpAgent;
+			return this.#defaultHttpAgent;
 		} else {
 			throw new Error('Unknown protocol');
 		}

--- a/src/agent-wrapper.ts
+++ b/src/agent-wrapper.ts
@@ -1,0 +1,25 @@
+import * as http from 'http';
+import * as https from 'http';
+import HttpAgent from 'agentkeepalive';
+import { AgentOptions } from './types';
+
+export default class Agent {
+	defaultHttpAgent: http.Agent;
+	defaultHttpsAgent: https.Agent;
+
+	constructor(agentOpts: AgentOptions) {
+		this.defaultHttpAgent = new HttpAgent(agentOpts);
+		// @ts-ignore
+		this.defaultHttpsAgent = new HttpAgent.HttpsAgent(agentOpts);
+	}
+
+	getAgent(url: string) {
+		if (url.startsWith('https:')) {
+			return this.defaultHttpsAgent;
+		} else if (url.startsWith('http:')) {
+			return this.defaultHttpAgent;
+		} else {
+			throw new Error('Unknown protocol');
+		}
+	}
+}

--- a/src/fetch-retry-error.ts
+++ b/src/fetch-retry-error.ts
@@ -1,11 +1,21 @@
+import { Response } from 'node-fetch';
+
 export default class FetchRetryError extends Error {
+	res: Response;
 	url: string;
 	statusCode: number;
 
-	constructor(url: string, statusCode: number, statusText: string) {
-		super(statusText);
-		this.url = url;
-		this.statusCode = statusCode;
+	constructor(res: Response) {
+		super(res.statusText);
+
+		if (Error.captureStackTrace) {
+			Error.captureStackTrace(this, FetchRetryError);
+		}
+
+		this.res = res;
+		this.name = this.constructor.name;
+		this.url = res.url;
+		this.statusCode = res.status;
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,9 @@ const debug = createDebug('@turist/fetch');
 function setupFetch(fetch: Fetch, agentOpts: AgentOptions = {}): any {
 	const agentWrapper = new AgentWrapper({ ...AGENT_OPTIONS, ...agentOpts });
 
-	return async function fetchWrap(url: string, opts: FetchOptions = {}): Promise<Response> {
+	return async function fetchWrap(url: string, fetchOpts: FetchOptions = {}): Promise<Response> {
+		const opts = Object.assign({}, fetchOpts);
+
 		// @ts-ignore
 		if (!opts.agent) {
 			// Add default `agent` if none was provided

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,12 @@ function setupFetch(fetch: Fetch, agentOpts: AgentOptions = {}): any {
 	return async function fetchWrap(url: string, fetchOpts: FetchOptions = {}): Promise<Response> {
 		const opts = Object.assign({}, fetchOpts);
 
+		if (opts.redirect) {
+			if (!['follow', 'manual', 'error'].includes(opts.redirect)) {
+				throw new Error('Invalid redirect option');
+			}
+		}
+
 		// @ts-ignore
 		if (!opts.agent) {
 			// Add default `agent` if none was provided
@@ -118,6 +124,13 @@ function setupFetch(fetch: Fetch, agentOpts: AgentOptions = {}): any {
 		}
 
 		if (isRedirect(res.status)) {
+			if (fetchOpts.redirect === 'manual') {
+				return res;
+			}
+			if (fetchOpts.redirect === 'error') {
+				throw new Error('Redirect rejected');
+			}
+
 			// TODO Loop detection
 			return fetchWrap(...makeRedirectOpts(res, opts, agentWrapper));
 		} else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,6 @@ function setupFetch(fetch: Fetch, agentOpts: AgentOptions = {}): any {
 		}
 
 		const retryOpts = Object.assign({
-			// timeouts will be [ 10, 50, 250 ]
 			minTimeout: MIN_TIMEOUT,
 			retries: MAX_RETRIES,
 			factor: FACTOR,
@@ -114,18 +113,17 @@ function setupFetch(fetch: Fetch, agentOpts: AgentOptions = {}): any {
 		let res: Response;
 		try {
 			res = await retry(async (_bail, attempt) => {
-				const isRetry = attempt < retryOpts.retries;
-
 				try {
 					const res = await fetch(url, opts);
 
 					debug('status %d', res.status);
-					if (res.status >= 500 && res.status < 600 && isRetry) {
+					if (res.status >= 500 && res.status < 600) {
 						throw new FetchRetryError(res);
 					} else {
 						return res;
 					}
 				} catch (err) {
+					const isRetry = attempt < retryOpts.retries;
 					const { method = 'GET' } = opts;
 					debug(`${method} ${url} error (${err.status}). ${isRetry ? 'retrying' : ''}`, err);
 					throw err;

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,10 @@ function setupFetch(fetch: Fetch, agentOpts: AgentOptions = {}): any {
 			throw new Error('Failed to create fetch opts');
 		}
 
+		if (!opts.headers.get('user-agent')) {
+			opts.headers.set('User-Agent', 'turist-fetch/1.0 (+https://github.com/turist-cloud/fetch)');
+		}
+
 		const [newUrl, host] = await parseHost(url, opts.headers);
 		opts.headers.set('host', host);
 

--- a/src/parse-host.ts
+++ b/src/parse-host.ts
@@ -1,5 +1,5 @@
 import { isIP } from 'net';
-import { parse as parseUrl, format as formatUrl } from 'url';
+import { parse as parseUrl } from 'url';
 import { Headers } from 'node-fetch';
 import resolve from './dns-resolve';
 
@@ -19,9 +19,9 @@ export default async function parseHost(url: string, headers: Headers) {
 			throw new Error('Unable to determine hostname');
 		}
 
-		// We need to create a new URL object here because parseURL doesn't
-		// return a functional WHATWG URL object but something that only
-		// looks similar and has the same properties.
+		// We need to create a new URL object here because url.parse() doesn't
+		// return a functional WHATWG URL object but something that only looks
+		// similar and has the same properties.
 		// TS doesn't know about the existence global WHATWG URL.
 		// @ts-ignore
 		const newUrl = new URL(parsedUrl.href);

--- a/src/parse-host.ts
+++ b/src/parse-host.ts
@@ -1,0 +1,33 @@
+import { isIP } from 'net';
+import { parse as parseUrl, format as formatUrl } from 'url';
+import { Headers } from 'node-fetch';
+import resolve from './dns-resolve';
+
+export default async function parseHost(url: string, headers: Headers) {
+	const parsedUrl = parseUrl(url);
+	const host = headers.get('host') || parsedUrl.host;
+
+	if (!host) {
+		throw new TypeError('Unable to determine Host');
+	}
+
+	headers.set('host', host);
+
+	const ip = isIP(parsedUrl.hostname || '');
+	if (ip === 0) {
+		if (!parsedUrl.hostname) {
+			throw new Error('Unable to determine hostname');
+		}
+
+		// We need to create a new URL object here because parseURL doesn't
+		// return a functional WHATWG URL object but something that only
+		// looks similar and has the same properties.
+		// TS doesn't know about the existence global WHATWG URL.
+		// @ts-ignore
+		const newUrl = new URL(parsedUrl.href);
+		newUrl.hostname = await resolve(parsedUrl.hostname);
+		url = newUrl.href;
+	}
+
+	return [url, host];
+}

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -1,0 +1,43 @@
+import { parse as parseUrl } from 'url';
+import { Headers, Response } from 'node-fetch';
+import AgentWrapper from './agent-wrapper';
+import { FetchOptions } from './types';
+
+export const isRedirect = (v: number) => ((v / 100) | 0) === 3
+
+export function makeRedirectOpts(res: Response, opts: FetchOptions, agentWrapper: AgentWrapper): [string, FetchOptions] {
+	const redirectOpts = Object.assign({}, opts);
+	redirectOpts.headers = new Headers(opts.headers);
+
+	// per fetch spec, for POST request with 301/302 response,
+	// or any request with 303 response, use GET when following redirect
+	if (
+		res.status === 303 ||
+		((res.status === 301 || res.status === 302) && opts.method === 'POST')
+	) {
+		redirectOpts.method = 'GET';
+		redirectOpts.headers.delete('content-length');
+		delete redirectOpts.body;
+	}
+
+	const location = res.headers.get('Location');
+	if (!location) {
+		throw new Error('"Location" header is missing');
+	}
+
+	const host = parseUrl(location).host;
+	if (!host) {
+		throw new Error('Cannot determine Host');
+	}
+
+	redirectOpts.headers.set('Host', host);
+
+	// TODO This might actually override user-provided agent
+	redirectOpts.agent = agentWrapper.getAgent(location);
+
+	if (opts.onRedirect) {
+		opts.onRedirect(res, redirectOpts);
+	}
+
+	return [location, redirectOpts];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,10 +409,10 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@25.1.2":
-  version "25.1.2"
-  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.1.2.tgz#1c4c8770c27906c7d8def5d2033df9dbd39f60da"
-  integrity sha512-EsPIgEsonlXmYV7GzUqcvORsSS9Gqxw/OvkGwHfAdpjduNRxMlhsav0O5Kb0zijc/eXSO/uW6SJt9nwull8AUQ==
+"@types/jest@25.1.3":
+  version "25.1.3"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.1.3.tgz#9b0b5addebccfb631175870be8ba62182f1bc35a"
+  integrity sha512-jqargqzyJWgWAJCXX96LBGR/Ei7wQcZBvRv0PLEu9ZByMfcs23keUJrKv9FMR6YZf9YCbfqDqgmY+JUBsnqhrg==
   dependencies:
     jest-diff "^25.1.0"
     pretty-format "^25.1.0"
@@ -816,11 +816,6 @@ callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
-camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
-  integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
@@ -3743,10 +3738,10 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-ts-jest@25.2.0:
-  version "25.2.0"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.2.0.tgz#dfd87c2b71ef4867f5a0a44f40cb9c67e02991ac"
-  integrity sha512-VaRdb0da46eorLfuHEFf0G3d+jeREcV+Wb/SvW71S4y9Oe8SHWU+m1WY/3RaMknrBsnvmVH0/rRjT8dkgeffNQ==
+ts-jest@25.2.1:
+  version "25.2.1"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-25.2.1.tgz#49bf05da26a8b7fbfbc36b4ae2fcdc2fef35c85d"
+  integrity sha512-TnntkEEjuXq/Gxpw7xToarmHbAafgCaAzOpnajnFC6jI7oo1trMzAHA04eWpc3MhV6+yvhE8uUBAmN+teRJh0A==
   dependencies:
     bs-logger "0.x"
     buffer-from "1.x"
@@ -3757,7 +3752,7 @@ ts-jest@25.2.0:
     mkdirp "0.x"
     resolve "1.x"
     semver "^5.5"
-    yargs-parser "10.x"
+    yargs-parser "^16.1.0"
 
 tslib@^1.9.0:
   version "1.10.0"
@@ -3808,10 +3803,10 @@ typescript-formatter@7.2.2:
     commandpost "^1.0.0"
     editorconfig "^0.15.0"
 
-typescript@3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -4027,13 +4022,6 @@ yaml@^1.7.2:
   integrity sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==
   dependencies:
     "@babel/runtime" "^7.6.3"
-
-yargs-parser@10.x:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
-  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
-  dependencies:
-    camelcase "^4.1.0"
 
 yargs-parser@^16.1.0:
   version "16.1.0"


### PR DESCRIPTION
- Shouldn't throw on response error
- Fix `retries` not respected properly
- Respect `Retry-After` header
- Create a class for the default Agent so that the agents won't be
  shared globally as that might be unexpected
- Fix Agent defaults
- Move redirect handling into a separate file to allow better
  test coverage
- Fix IP caching and fetching using IP addresses
- Do not modify the original opts object
- Allow redirect opt like in node-fetch
- Add our own user-agent