### PR TITLE
Fix response URL and Host header on relative redirects

### DIFF
--- a/__test__/redirect.test.ts
+++ b/__test__/redirect.test.ts
@@ -38,7 +38,7 @@ describe('makeRedirectOpts()', () => {
 
 		const [location, redirectOpts] = makeRedirectOpts(res, opts, agentWrapper);
 
-		expect(location).toBe('https://no.ne');
+		expect(location).toBe('https://no.ne/');
 		expect(redirectOpts.method).toBe('GET');
 	});
 
@@ -58,7 +58,7 @@ describe('makeRedirectOpts()', () => {
 
 		const [location, redirectOpts] = makeRedirectOpts(res, opts, agentWrapper);
 
-		expect(location).toBe('https://no.ne');
+		expect(location).toBe('https://no.ne/');
 		expect(redirectOpts.method).toBe('GET');
 		expect(redirectOpts.body).not.toBeDefined();
 

--- a/__test__/util.ts
+++ b/__test__/util.ts
@@ -26,3 +26,8 @@ export function listen(server: Server, ...args: any[]) {
 		server.listen(...args);
 	});
 }
+
+export function time() {
+	const [seconds, nanos] = process.hrtime();
+	return seconds * 1000 + nanos / 1000000;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ function setupFetch(fetch: Fetch, agentOpts: AgentOptions = {}): any {
 		// node-fetch changes the resolves the Location header to an absolute
 		// URL with `manual` but luckily an invalid value here will turn off
 		// that feature.
+		// @ts-ignore
 		opts.redirect = 'manual-dont-change';
 
 		opts.headers = new Headers(opts.headers);
@@ -145,6 +146,7 @@ function setupFetch(fetch: Fetch, agentOpts: AgentOptions = {}): any {
 
 				return res;
 			}
+			// @ts-ignore
 			if (fetchOpts.redirect === 'manual-dont-change') {
 				return res;
 			}

--- a/src/redirect.ts
+++ b/src/redirect.ts
@@ -1,4 +1,7 @@
-import { parse as parseUrl } from 'url';
+import {
+	parse as parseUrl,
+	resolve as resolveUrl
+} from 'url';
 import { Headers, Response } from 'node-fetch';
 import AgentWrapper from './agent-wrapper';
 import { FetchOptions } from './types';
@@ -24,8 +27,9 @@ export function makeRedirectOpts(res: Response, opts: FetchOptions, agentWrapper
 	if (!location) {
 		throw new Error('"Location" header is missing');
 	}
+	const locationUrl = resolveUrl(res.url, location);
 
-	const host = parseUrl(location).host;
+	const host = parseUrl(locationUrl).host;
 	if (!host) {
 		throw new Error('Cannot determine Host');
 	}
@@ -33,11 +37,11 @@ export function makeRedirectOpts(res: Response, opts: FetchOptions, agentWrapper
 	redirectOpts.headers.set('Host', host);
 
 	// TODO This might actually override user-provided agent
-	redirectOpts.agent = agentWrapper.getAgent(location);
+	redirectOpts.agent = agentWrapper.getAgent(locationUrl);
 
 	if (opts.onRedirect) {
 		opts.onRedirect(res, redirectOpts);
 	}
 
-	return [location, redirectOpts];
+	return [locationUrl, redirectOpts];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,6 @@ import FetchRetryError from './fetch-retry-error';
 export interface FetchOptions extends RequestInit {
 	agent?: https.Agent | http.Agent;
 	retry?: RetryOptions;
-	redirect?: 'follow' | 'manual' | 'error' | 'manual-dont-change';
 	onRedirect?: (res: Response, redirectOpts: FetchOptions) => void;
 	onRetry?: (error: FetchRetryError, opts: FetchOptions) => void;
 	body?: any; // allows automatic JSON serialization of objects

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ import FetchRetryError from './fetch-retry-error';
 export interface FetchOptions extends RequestInit {
 	agent?: https.Agent | http.Agent;
 	retry?: RetryOptions;
+	redirect?: 'follow' | 'manual' | 'error' | 'manual-dont-change';
 	onRedirect?: (res: Response, redirectOpts: FetchOptions) => void;
 	onRetry?: (error: FetchRetryError, opts: FetchOptions) => void;
 	body?: any; // allows automatic JSON serialization of objects


### PR DESCRIPTION
`node-fetch` mangles the `Location` header when `manual` redirect
mode is selected. As a workaround we can use an invalid mode to
stop it from happening: https://github.com/node-fetch/node-fetch/issues/417#issuecomment-587233352

Now we also must resolve the relative URLs by ourself and for
backwards compatibility provide the same mangling that `node-fetch`
does in `manual` mode.