### PR TITLE
Bump agentkeepalive to fix timeouts

### DIFF
--- a/__test__/timeout.test.ts
+++ b/__test__/timeout.test.ts
@@ -1,0 +1,35 @@
+import { Server, createServer, IncomingMessage, ServerResponse } from "http";
+import nodeFetch from "node-fetch";
+import { getAddr, listen } from "./util";
+import createFetch from "../src";
+
+const fetch = createFetch(nodeFetch, { timeout: 2000 });
+let servers: Server[] = [];
+
+afterEach(() => {
+	while (servers.length) {
+		const server = servers.pop();
+
+		if (!server) {
+			continue;
+		}
+
+		server.close();
+	}
+});
+
+test("Times out after the specified time", async () => {
+	const server = createServer(
+		(_req: IncomingMessage, _res: ServerResponse) => {
+			// hang
+		}
+	);
+	servers.push(server);
+	await listen(server);
+
+	const { port } = getAddr(server);
+
+	await expect(
+		fetch(`http://127.0.0.1:${port}`, { retry: { retries: 0 } })
+	).rejects.toThrow(/Socket timeout/);
+});

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@types/lru-cache": "5.1.0",
     "@zeit/git-hooks": "0.1.4",
     "@zeit/ncc": "0.21.1",
-    "agentkeepalive": "4.1.0",
+    "agentkeepalive": "4.1.3",
     "async-retry-ng": "2.0.1",
     "debug": "4.1.1",
     "jest": "25.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -495,10 +495,10 @@ acorn@^7.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
-agentkeepalive@4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.0.tgz#a48e040ed16745dd29ce923675f60c9c90f39ee0"
-  integrity sha512-CW/n1wxF8RpEuuiq6Vbn9S8m0VSYDMnZESqaJ6F2cWN9fY8rei2qaxweIaRgq+ek8TqfoFIsUjaGNKGGEHElSg==
+agentkeepalive@4.1.3:
+  version "4.1.3"
+  resolved "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.1.3.tgz#360a09d743a1f4fde749f9ba07caa6575d08259a"
+  integrity sha512-wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==
   dependencies:
     debug "^4.1.0"
     depd "^1.1.2"


### PR DESCRIPTION
agentkeepalive <= 4.1.1 has a bug that prevents timeouts from working on node 12. Here is the fix in agentkeepalive: https://github.com/node-modules/agentkeepalive/pull/88/files

This adds a test to assert that timeouts work and bumps agentkeepalive to a working version.